### PR TITLE
Add macOS and Linux builds with artifacts and a beta release

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,67 @@
+permissions:
+  contents: write
+
+on:
+  push:
+    branches: ["main", "master"]
+
+name: Beta
+
+env:
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: macos-latest
+          TARGET: aarch64-apple-darwin
+          ARTIFACT_NAME: tes3util-macos-arm64
+
+        - os: ubuntu-latest
+          TARGET: x86_64-unknown-linux-gnu
+          ARTIFACT_NAME: tes3util-linux-x64
+
+        - os: windows-latest
+          TARGET: x86_64-pc-windows-msvc
+          EXTENSION: .exe
+          ARTIFACT_NAME: tes3util-windows-x64
+
+    steps:
+    - name: Building ${{ matrix.TARGET }}
+      run: echo "${{ matrix.TARGET }}"
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.TARGET }}
+        override: true
+
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --verbose --release --target=${{ matrix.TARGET }}
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.ARTIFACT_NAME }}
+        path: target/${{ matrix.TARGET }}/release/tes3util${{ matrix.EXTENSION }}
+
+    # add to 'beta' release
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: beta
+        overwrite_files: true
+        files: target/${{ matrix.TARGET }}/release/tes3util${{ matrix.EXTENSION }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -39,16 +39,11 @@ jobs:
       with:
         submodules: 'true'
 
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        target: ${{ matrix.TARGET }}
-        override: true
+        targets: ${{ matrix.TARGET }}
 
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --release --target=${{ matrix.TARGET }}
+    - run: cargo build --verbose --release --target=${{ matrix.TARGET }}
 
     - name: Upload build artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Adds a new `Beta` workflow (`.github/workflows/beta.yml`) that builds `tes3util` across macOS, Linux, and Windows, uploads each binary as a build artifact, and drops them into a `beta` release on pushes to `main`/`master`. Modeled on the provided template.

## Build matrix

| OS | Target | Artifact |
|----|--------|----------|
| macos-latest | aarch64-apple-darwin | `tes3util-macos-arm64` |
| ubuntu-latest | x86_64-unknown-linux-gnu | `tes3util-linux-x64` |
| windows-latest | x86_64-pc-windows-msvc | `tes3util-windows-x64` |

macOS and Linux are the newly added targets; Windows is retained since it was already released manually via `release.yml`.

## Notes / adaptations

- **Binary name** set to `tes3util` (the template referenced a different project).
- **`submodules: 'true'`** on checkout — `tes3` is a git submodule and path dependency, so builds fail without it.
- **No `cross`** — native `cargo build` per runner, since `cross` only runs on a Linux host and would break the macOS/Windows jobs.
- **Toolchain** uses the maintained `dtolnay/rust-toolchain@stable` (matching the existing `rust.yml`) rather than the archived `actions-rs/*` actions.
- Release tag is `beta`.

Added as a separate workflow so the existing PR/push CI (`rust.yml`) and manual `release.yml` stay untouched, and releases only fire on pushes to `main`/`master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wg57GznzQLeBz57PPSf9wp)_